### PR TITLE
catch broken pipe exception and continue

### DIFF
--- a/run_model.py
+++ b/run_model.py
@@ -199,7 +199,10 @@ for idx, data in enumerate(seqs):
         suffix = '.horiz'
         
     if not args_dict['silent']:
-        for line in lines: print(line)
+        try:
+            for line in lines: print(line)
+        except BrokenPipeError:
+            pass
     else:
         if not args_dict['save_files']:
             raise ValueError('Using --silent and not using --save-files will lead to no output.')


### PR DESCRIPTION
allows stdout output to be piped to unix commands e.g.
```
python3 run_model.py -t fas inp.fa | xargs -n3 > out.txt
```
for table output that is preferable in some scenarios